### PR TITLE
Check for existence of explicitly passed config files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [1.38.0, beta, nightly]
+        rust: [beta, nightly]
 
     steps:
       - uses: actions/checkout@v2

--- a/src/app.rs
+++ b/src/app.rs
@@ -172,7 +172,7 @@ fn init_paths(args: Vec<String>) -> Vec<String> {
         } else if args[i] == INIT_FILE_FLAG {
             let file = Path::new(&args[i + 1]);
             if !file.exists() {
-                eprintln!("Config file {} does not exist", args[i+1]);
+                eprintln!("Config file {} does not exist", args[i + 1]);
                 std::process::exit(1);
             }
             possible_paths.push(args[i + 1].clone());

--- a/src/app.rs
+++ b/src/app.rs
@@ -170,6 +170,11 @@ fn init_paths(args: Vec<String>) -> Vec<String> {
             ignore_init = true;
             break;
         } else if args[i] == INIT_FILE_FLAG {
+            let file = Path::new(&args[i + 1]);
+            if !file.exists() {
+                eprintln!("Config file {} does not exist", args[i+1]);
+                std::process::exit(1);
+            }
             possible_paths.push(args[i + 1].clone());
             continue;
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -162,7 +162,7 @@ const NO_INIT_FILE_FLAG: &str = "--args-only";
 const LEDGER_PATHS_UNDER_DIR: &str = "~/.ledgerrc";
 const LEDGER_PATHS: &str = ".ledgerrc";
 
-fn init_paths(args: Vec<String>) -> Vec<String> {
+fn init_paths(args: Vec<String>) -> Result<Vec<String>, ()> {
     let mut possible_paths: Vec<String> = Vec::new();
     let mut ignore_init = false;
     for i in 0..args.len() {
@@ -172,8 +172,8 @@ fn init_paths(args: Vec<String>) -> Vec<String> {
         } else if args[i] == INIT_FILE_FLAG {
             let file = Path::new(&args[i + 1]);
             if !file.exists() {
-                eprintln!("Config file {} does not exist", args[i + 1]);
-                std::process::exit(1);
+                eprintln!("Config file '{}' does not exist", args[i + 1]);
+                return Err(());
             }
             possible_paths.push(args[i + 1].clone());
             continue;
@@ -184,16 +184,16 @@ fn init_paths(args: Vec<String>) -> Vec<String> {
         possible_paths.push(shellexpand::tilde(LEDGER_PATHS_UNDER_DIR).to_string());
         possible_paths.push(LEDGER_PATHS.to_string());
 
-        possible_paths
+        Ok(possible_paths)
     } else {
-        vec![]
+        Ok(vec![])
     }
 }
 
 /// Entry point for the command line app
 pub fn run_app(mut args: Vec<String>) -> Result<(), ()> {
     let mut config_file = None;
-    let possible_paths = init_paths(args.clone());
+    let possible_paths = init_paths(args.clone())?;
     for path in possible_paths.iter() {
         let file = Path::new(path);
         if file.exists() {

--- a/src/commands/register.rs
+++ b/src/commands/register.rs
@@ -12,7 +12,7 @@ use terminal_size::{terminal_size, Width};
 pub fn execute(options: &CommonOpts) -> Result<(), Error> {
     // Get options from options
     let path = options.input_file.clone();
-    let no_balance_check: bool = options.no_balance_check;
+    let _no_balance_check: bool = options.no_balance_check;
     // Now work
     let mut tokenizer: Tokenizer = Tokenizer::from(&path);
     let items = tokenizer.tokenize();

--- a/tests/test_commands.rs
+++ b/tests/test_commands.rs
@@ -326,6 +326,16 @@ fn strict() {
 }
 
 #[test]
+/// It should fail with no config file
+fn no_config_file() {
+    let args_1 = &["bal", "--init-file", "a file that does not exist"];
+    let assert_1 = Command::cargo_bin("dinero").unwrap().args(args_1).assert();
+    let output_1 = String::from_utf8(assert_1.get_output().to_owned().stderr).unwrap();
+    assert_eq!(output_1.lines().into_iter().count(), 1);
+    test_err(args_1);
+}
+
+#[test]
 #[should_panic()]
 /// Check that pedantic works
 fn pedantic() {


### PR DESCRIPTION
If you pass an ```--init-file "a file"```explicitly, it will check for its existence and terminate if not found.