### PR TITLE
Check currencies in transactions, #fixes 104

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ Changelog file for dinero-rs project, a command line application for managing fi
 - ```--args-only``` flag to ignore init files
 ### Changed
 - Check whether dependencies are updated or not with deps.rs service
-
+### Fixed
+- [```--strict``` and ```--pedantic``` working properly](https://github.com/frosklis/dinero-rs/issues/104)
 ## [0.25.0] - 2021-03-31
 ### Added
 - nicer error reporting

--- a/src/app.rs
+++ b/src/app.rs
@@ -211,7 +211,7 @@ pub fn run_app(mut args: Vec<String>) -> Result<(), ()> {
                 Some(c) => match c {
                     '-' => {
                         let message = format!("Bad config file {:?}\n{}", file, line);
-                        assert!(line.starts_with("--"), message);
+                        assert!(line.starts_with("--"), "{}", message);
                         let mut iter = line.split_whitespace();
                         let option = iter.next().unwrap();
                         if !args.iter().any(|x| {

--- a/src/commands/accounts.rs
+++ b/src/commands/accounts.rs
@@ -7,7 +7,7 @@ use std::ops::Deref;
 
 pub fn execute(path: PathBuf, options: &CommonOpts) -> Result<(), Error> {
     let mut tokenizer: Tokenizer = Tokenizer::from(&path);
-    let items = tokenizer.tokenize();
+    let items = tokenizer.tokenize(options);
     let ledger = items.to_ledger(options)?;
     let mut accounts = ledger
         .accounts

--- a/src/commands/balance.rs
+++ b/src/commands/balance.rs
@@ -19,7 +19,7 @@ pub fn execute(options: &CommonOpts, flat: bool, show_total: bool) -> Result<(),
     let path: PathBuf = options.input_file.clone();
     let depth = options.depth;
     let mut tokenizer: Tokenizer = Tokenizer::from(&path);
-    let items = tokenizer.tokenize();
+    let items = tokenizer.tokenize(options);
     let mut ledger = items.to_ledger(options)?;
 
     let mut balances: HashMap<Rc<Account>, Balance> = HashMap::new();

--- a/src/commands/commodities.rs
+++ b/src/commands/commodities.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 
 pub fn execute(path: PathBuf, options: &CommonOpts) -> Result<(), Error> {
     let mut tokenizer: Tokenizer = Tokenizer::from(&path);
-    let items = tokenizer.tokenize();
+    let items = tokenizer.tokenize(options);
     let ledger = items.to_ledger(options)?;
     let mut commodities = ledger
         .commodities

--- a/src/commands/payees.rs
+++ b/src/commands/payees.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 
 pub fn execute(path: PathBuf, options: &CommonOpts) -> Result<(), Error> {
     let mut tokenizer: Tokenizer = Tokenizer::from(&path);
-    let items = tokenizer.tokenize();
+    let items = tokenizer.tokenize(options);
     let ledger = items.to_ledger(options)?;
     let mut payees = ledger
         .payees

--- a/src/commands/prices.rs
+++ b/src/commands/prices.rs
@@ -6,7 +6,7 @@ use crate::{parser::Tokenizer, CommonOpts};
 
 pub fn execute(path: PathBuf, options: &CommonOpts) -> Result<(), Error> {
     let mut tokenizer: Tokenizer = Tokenizer::from(&path);
-    let items = tokenizer.tokenize();
+    let items = tokenizer.tokenize(options);
 
     let ledger = items.to_ledger(options)?;
     for price in ledger.prices.deref() {

--- a/src/commands/register.rs
+++ b/src/commands/register.rs
@@ -15,7 +15,7 @@ pub fn execute(options: &CommonOpts) -> Result<(), Error> {
     let _no_balance_check: bool = options.no_balance_check;
     // Now work
     let mut tokenizer: Tokenizer = Tokenizer::from(&path);
-    let items = tokenizer.tokenize();
+    let items = tokenizer.tokenize(options);
     let mut ledger = items.to_ledger(options)?;
 
     let mut balance = Balance::new();

--- a/src/commands/statistics.rs
+++ b/src/commands/statistics.rs
@@ -8,7 +8,7 @@ use crate::{error::Error, CommonOpts};
 /// Prints summary statistics from the ledger
 pub fn execute(path: PathBuf, options: &CommonOpts) -> Result<(), Error> {
     let mut tokenizer: Tokenizer = Tokenizer::from(&path);
-    let items = tokenizer.tokenize();
+    let items = tokenizer.tokenize(options);
     let ledger = items.to_ledger(options)?;
 
     // Number of transactions

--- a/src/models.rs
+++ b/src/models.rs
@@ -378,6 +378,7 @@ impl ParsedLedger {
                 for comment in parsed.comments.iter() {
                     transaction.tags.append(&mut comment.get_tags());
                 }
+
                 // Go posting by posting
                 for p in parsed.postings.borrow().iter() {
                     let payee = match &p.payee {

--- a/src/models/price.rs
+++ b/src/models/price.rs
@@ -313,7 +313,7 @@ mod tests {
         // Copy from balance command
         let path = PathBuf::from("tests/example_files/demo.ledger");
         let mut tokenizer = Tokenizer::from(&path);
-        let items = tokenizer.tokenize();
+        let items = tokenizer.tokenize(options);
         let ledger = items.to_ledger(&CommonOpts::new()).unwrap();
 
         let currency = ledger.commodities.get("EUR").unwrap();

--- a/src/models/price.rs
+++ b/src/models/price.rs
@@ -313,8 +313,9 @@ mod tests {
         // Copy from balance command
         let path = PathBuf::from("tests/example_files/demo.ledger");
         let mut tokenizer = Tokenizer::from(&path);
-        let items = tokenizer.tokenize(options);
-        let ledger = items.to_ledger(&CommonOpts::new()).unwrap();
+        let options = CommonOpts::new();
+        let items = tokenizer.tokenize(&options);
+        let ledger = items.to_ledger(&options).unwrap();
 
         let currency = ledger.commodities.get("EUR").unwrap();
         let multipliers = conversion(

--- a/src/parser/include.rs
+++ b/src/parser/include.rs
@@ -1,4 +1,8 @@
-use crate::parser::{ParsedLedger, Rule, Tokenizer};
+use crate::{
+    models::Currency,
+    parser::{ParsedLedger, Rule, Tokenizer},
+    CommonOpts, List,
+};
 use glob::glob;
 use pest::iterators::Pair;
 
@@ -9,7 +13,12 @@ impl<'a> Tokenizer<'a> {
     ///
     /// Add the found file of files it it has wildcards in the pattern to the queue of files to process and process them.
     /// TODO this is a good place to include parallelism
-    pub fn include(&self, element: Pair<Rule>) -> ParsedLedger {
+    pub fn include(
+        &self,
+        element: Pair<Rule>,
+        options: &CommonOpts,
+        commodities: &List<Currency>,
+    ) -> ParsedLedger {
         let mut pattern = String::new();
         let mut files: Vec<PathBuf> = Vec::new();
         if let Some(current_path) = self.file {
@@ -42,7 +51,8 @@ impl<'a> Tokenizer<'a> {
             for p in self.seen_files.iter() {
                 inner_tokenizer.seen_files.insert(*p);
             }
-            let mut new_items: ParsedLedger = inner_tokenizer.tokenize();
+            let mut new_items: ParsedLedger =
+                inner_tokenizer.tokenize_with_currencies(&options, Some(commodities));
             items.append(&mut new_items);
         }
         items

--- a/tests/test_accounts.rs
+++ b/tests/test_accounts.rs
@@ -46,7 +46,7 @@ fn test_account_names() {
     ];
     for (i, mut tokenizer) in tokenizers.into_iter().enumerate() {
         println!("Test case #{}", i);
-        let parsed = tokenizer.tokenize();
+        let parsed = tokenizer.tokenize(&CommonOpts::new());
         let mut num_accounts = parsed.accounts.len();
         assert_eq!(num_accounts, 0, "There should be no accounts when parsed");
         let mut options = CommonOpts::new();
@@ -66,7 +66,7 @@ fn test_account_directive() {
             .to_string(),
     );
 
-    let parsed = tokenizer.tokenize();
+    let parsed = tokenizer.tokenize(&CommonOpts::new());
     let num_accounts = parsed.accounts.len();
     assert_eq!(num_accounts, 1, "Parse one account")
 }

--- a/tests/test_balances.rs
+++ b/tests/test_balances.rs
@@ -17,7 +17,8 @@ fn test_balances() {
 "
         .to_string(),
     );
-    let parsed = tokenizer.tokenize();
-    let ledger = parsed.to_ledger(&CommonOpts::new());
+    let options = CommonOpts::new();
+    let parsed = tokenizer.tokenize(&options);
+    let ledger = parsed.to_ledger(&options);
     assert!(ledger.is_ok(), "This should balance");
 }

--- a/tests/test_currency_formats.rs
+++ b/tests/test_currency_formats.rs
@@ -36,8 +36,9 @@ commodity ACME
         "
         .to_string(),
     );
-    let items = tokenizer.tokenize();
-    let ledger = items.to_ledger(&CommonOpts::new()).unwrap();
+    let options = CommonOpts::new();
+    let items = tokenizer.tokenize(&options);
+    let ledger = items.to_ledger(&options).unwrap();
     let eur = ledger.get_commodities().get("eur").unwrap();
     let usd = ledger.get_commodities().get("usd").unwrap();
     let acme = ledger.get_commodities().get("acme").unwrap();

--- a/tests/test_exchange.rs
+++ b/tests/test_exchange.rs
@@ -29,8 +29,9 @@ P 2020-07-01 EUR 1.5 USD
         "
         .to_string(),
     );
-    let items = tokenizer.tokenize();
-    let ledger = items.to_ledger(&CommonOpts::new()).unwrap();
+    let options = CommonOpts::new();
+    let items = tokenizer.tokenize(&options);
+    let ledger = items.to_ledger(&options).unwrap();
     let eur = ledger.get_commodities().get("eur").unwrap();
     let usd = ledger.get_commodities().get("usd").unwrap();
     let acme = ledger.get_commodities().get("acme").unwrap();

--- a/tests/test_failures.rs
+++ b/tests/test_failures.rs
@@ -14,7 +14,7 @@ fn not_money() {
 "
         .to_string(),
     );
-    let parsed = tokenizer.tokenize();
+    let parsed = tokenizer.tokenize(&CommonOpts::new());
 
     // It parses -- it has not panicked
     assert!(true);

--- a/tests/test_include.rs
+++ b/tests/test_include.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 fn test_include() {
     let p1 = PathBuf::from("tests/example_files/include.ledger".to_string());
     let mut tokenizer: Tokenizer = Tokenizer::from(&p1);
-    let _res = tokenizer.tokenize();
+    let _res = tokenizer.tokenize(&CommonOpts::new());
     // simply that it does not panic
     // todo change for something meaningful
     assert!(true);
@@ -18,7 +18,7 @@ fn test_include() {
 fn test_build_ledger_from_demo() {
     let p1 = PathBuf::from("tests/example_files/demo.ledger".to_string());
     let mut tokenizer: Tokenizer = Tokenizer::from(&p1);
-    let items = tokenizer.tokenize();
+    let items = tokenizer.tokenize(CommonOpts::new());
     let ledger = items.to_ledger(&CommonOpts::new());
     assert!(ledger.is_ok());
 }
@@ -33,7 +33,7 @@ fn test_fail() {
 "
         .to_string(),
     );
-    let parsed = tokenizer.tokenize();
+    let parsed = tokenizer.tokenize(&CommonOpts::new());
     // It parses
     assert!(true);
 
@@ -52,8 +52,9 @@ fn comment_no_spaces() {
         "
         .to_string(),
     );
-    let items = tokenizer.tokenize();
-    let ledger = items.to_ledger(&CommonOpts::new());
+    let options = CommonOpts::new();
+    let items = tokenizer.tokenize(&options);
+    let ledger = items.to_ledger(&options);
     assert!(ledger.is_ok());
 }
 #[test]
@@ -66,7 +67,8 @@ fn comment_spaces() {
         "
         .to_string(),
     );
-    let items = tokenizer.tokenize();
-    let ledger = items.to_ledger(&CommonOpts::new());
+    let options = CommonOpts::new();
+    let items = tokenizer.tokenize(&options);
+    let ledger = items.to_ledger(&options);
     assert!(ledger.is_ok());
 }

--- a/tests/test_include.rs
+++ b/tests/test_include.rs
@@ -18,8 +18,9 @@ fn test_include() {
 fn test_build_ledger_from_demo() {
     let p1 = PathBuf::from("tests/example_files/demo.ledger".to_string());
     let mut tokenizer: Tokenizer = Tokenizer::from(&p1);
-    let items = tokenizer.tokenize(CommonOpts::new());
-    let ledger = items.to_ledger(&CommonOpts::new());
+    let options = CommonOpts::new();
+    let items = tokenizer.tokenize(&options);
+    let ledger = items.to_ledger(&options);
     assert!(ledger.is_ok());
 }
 


### PR DESCRIPTION
Because currencies were added when encountered from transactions, they
were effectively not checked.

Now they are checked. To do that, the include function had to be
modified along with the parsers (added the options) and all the places
it is called.