### PR TITLE
Fix #121 lost payees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Changelog file for dinero-rs project, a command line application for managing fi
 - Show more info when loading the repl
 - Ability to [reload the journal](https://github.com/frosklis/dinero-rs/issues/116) 
 ## Fixed
-- Some payees were ```""``` (empty string) - not anymore :)
+- [```Some payees were None```](https://github.com/frosklis/dinero-rs/issues/121)
 
 ## [0.29.1] - 2021-08-17
 ## Changed

--- a/src/models/transaction.rs
+++ b/src/models/transaction.rs
@@ -87,9 +87,15 @@ impl<T> Transaction<T> {
         }
     }
     pub fn get_payee(&self, payees: &List<Payee>) -> Option<Rc<Payee>> {
-        match payees.get(&self.description) {
-            Ok(x) => Some(x.clone()),
-            Err(_) => None,
+        match &self.payee {
+            Some(payee) => match payees.get(payee) {
+                Ok(x) => Some(x.clone()),
+                Err(_) => panic!("Couldn't find payee {}", payee),
+            },
+            None => match payees.get(&self.description) {
+                Ok(x) => Some(x.clone()),
+                Err(_) => None,
+            },
         }
     }
 }

--- a/src/parser/tokenizers/transaction.rs
+++ b/src/parser/tokenizers/transaction.rs
@@ -237,12 +237,13 @@ mod tests {
     use crate::{parser::Tokenizer, CommonOpts};
 
     #[test]
+
     fn difficult_transaction_head() {
         let mut tokenizer = Tokenizer::from(
             "2022-05-13 ! (8760) Intereses | EstateGuru
-                EstateGuru               1.06 EUR
-                Ingresos:Rendimientos
-                "
+            EstateGuru               1.06 EUR
+            Ingresos:Rendimientos
+            "
             .to_string(),
         );
 


### PR DESCRIPTION
There were two mistakes:
- when going from raw to real transaction, the payee was not being
copied
- the ```get_payee``` function was only looking at the description