### PR TITLE
More roi output options #115

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog file for dinero-rs project, a command line application for managing fi
 ## [0.32.0] - xxx
 ### Added
 - Implemented ```date-format```
+- Added ```--calendar``` to the ```roi``` command, showing a [calendar view of TWR](https://github.com/frosklis/dinero-rs/issues/115).
+- Added ```--no-summary``` flag to the ```roi``` command, to suppress the summary after the table
 ### Fixed
 - [```args-only```](https://github.com/frosklis/dinero-rs/issues/120)
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -67,6 +67,13 @@ enum Command {
 
         #[structopt(flatten)]
         period_grouping: PeriodGroup,
+
+        /// Whether to display as calendar table
+        #[structopt(long = "--calendar")]
+        calendar: bool,
+        /// Do not display summary
+        #[structopt(long = "--no-summary")]
+        calendar: bool,
     },
 }
 
@@ -402,6 +409,8 @@ fn execute_command(opt: Opt, maybe_ledger: Option<Ledger>) -> Result<(), ()> {
             cash_flows,
             assets_value,
             period_grouping,
+            calendar,
+            no_summary,
         } => {
             if options.force_color {
                 env::set_var("CLICOLOR_FORCE", "1");
@@ -412,6 +421,8 @@ fn execute_command(opt: Opt, maybe_ledger: Option<Ledger>) -> Result<(), ()> {
                 cash_flows,
                 assets_value,
                 Frequency::from(period_grouping),
+                calendar,
+                !no_summary,
             )
         }
         Command::Commodities(options) => {

--- a/src/app.rs
+++ b/src/app.rs
@@ -73,7 +73,7 @@ enum Command {
         calendar: bool,
         /// Do not display summary
         #[structopt(long = "--no-summary")]
-        calendar: bool,
+        no_summary: bool,
     },
 }
 

--- a/tests/example_files/hledger_roi.ledger
+++ b/tests/example_files/hledger_roi.ledger
@@ -30,6 +30,6 @@
   investment:snake oil
   equity:unrealized gains  -$0.25
 
-2010-01-01 Start the new year with a new investment
+2020-01-01 Start the new year with a new investment
   assets:cash  -$100
   investment:snake oil

--- a/tests/example_files/hledger_roi.ledger
+++ b/tests/example_files/hledger_roi.ledger
@@ -1,4 +1,5 @@
 ; This file was copied from https://hledger.org/return-on-investment.html
+; it was later modified
 ; will test with a command similar to:
 ; roi --init-file tests/example_files/empty_ledgerrc -f tests/example_files/hledger_roi.ledger --cash-flows cash --assets-value snake -X $
 2019-01-01 Investing in Snake Oil
@@ -28,3 +29,7 @@
 2019-12-31 Recording the growth of Snake Oil
   investment:snake oil
   equity:unrealized gains  -$0.25
+
+2010-01-01 Start the new year with a new investment
+  assets:cash  -$100
+  investment:snake oil

--- a/tests/test_commands.rs
+++ b/tests/test_commands.rs
@@ -427,7 +427,7 @@ fn roi() {
 
     test_args(args);
 }
-
+#[test]
 fn roi_calendar() {
     let args = &[
         "roi",
@@ -447,7 +447,7 @@ fn roi_calendar() {
 
     for (i, line) in output.lines().into_iter().enumerate() {
         match i {
-            2 => {
+            3 => {
                 assert!(String::from(line).contains("2.50%"));
                 assert!(String::from(line).contains("2.38%"));
             }

--- a/tests/test_commands.rs
+++ b/tests/test_commands.rs
@@ -428,6 +428,36 @@ fn roi() {
     test_args(args);
 }
 
+fn roi_calendar() {
+    let args = &[
+        "roi",
+        "--init-file",
+        "tests/example_files/empty_ledgerrc",
+        "-f",
+        "tests/example_files/hledger_roi.ledger",
+        "--cash-flows",
+        "cash",
+        "--assets-value",
+        "snake",
+        "-Q",
+        "--calendar",
+    ];
+    let assert_1 = Command::cargo_bin("dinero").unwrap().args(args).assert();
+    let output = String::from_utf8(assert_1.get_output().to_owned().stdout).unwrap();
+
+    for (i, line) in output.lines().into_iter().enumerate() {
+        match i {
+            2 => {
+                assert!(String::from(line).contains("2.50%"));
+                assert!(String::from(line).contains("2.38%"));
+            }
+            _ => assert!(true),
+        }
+    }
+
+    test_args(args);
+}
+
 /// It should be equivalent to pass the args-only to passing an empty ledgerrc
 #[test]
 fn args_only() {

--- a/tests/test_repl.rs
+++ b/tests/test_repl.rs
@@ -1,7 +1,4 @@
 use assert_cmd::Command;
-use dinero::run_app;
-use std::thread;
-use std::time::Duration;
 mod common;
 // const CARGO: &'static str = env!("CARGO");
 


### PR DESCRIPTION
- Added ```--calendar``` to the ```roi``` command, showing a [calendar view of TWR](https://github.com/frosklis/dinero-rs/issues/115).
- Added ```--no-summary``` flag to the ```roi``` command, to suppress the summary after the table

This pull request fixes #115
