### PR TITLE
simplify app rs

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -174,37 +174,6 @@ pub struct CommonOpts {
     pub related: bool,
 }
 
-
-impl CommonOpts {
-    // TODO remove this function
-    pub fn new() -> Self {
-        CommonOpts {
-            input_file: PathBuf::new(),
-            args_only: false,
-            init_file: None,
-            depth: None,
-            query: vec![],
-            real: false,
-            begin: None,
-            end: None,
-            period: None,
-            now: None,
-            no_balance_check: false,
-            exchange: None,
-            date_format: "%y-%b-%d".into(),
-            force_color: false,
-            force_pager: false,
-            effective: false,
-            strict: false,
-            pedantic: false,
-            unrealized_gains: None,
-            unrealized_losses: None,
-            collapse: false,
-            related: false,
-        }
-    }
-}
-
 /// Groups of time
 #[derive(StructOpt, Clone, Debug)]
 pub struct PeriodGroup {

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -72,7 +72,7 @@ pub fn filter_expression(
 /// let processed = preprocess_query(&params, &false);
 /// assert_eq!(processed, "((payee =~ /(?i)payee/) or (account =~ /(?i)savings/) and (account =~ /(?i)checking/) and (/aeiou/))")
 /// ```
-pub fn preprocess_query(query: &Vec<String>, related:&bool) -> String {
+pub fn preprocess_query(query: &Vec<String>, related: &bool) -> String {
     let mut expression = String::new();
     let mut and = false;
     let mut first = true;
@@ -132,7 +132,7 @@ pub fn preprocess_query(query: &Vec<String>, related:&bool) -> String {
         expr = false;
         first = false;
     }
-    
+
     if *related {
         format!("(any({}) and not({}))", expression, expression)
     } else {

--- a/src/models.rs
+++ b/src/models.rs
@@ -525,6 +525,8 @@ pub trait FromDirective {
 
 #[cfg(test)]
 mod tests {
+    use structopt::StructOpt;
+
     use crate::{parser::Tokenizer, CommonOpts};
 
     #[test]
@@ -536,7 +538,7 @@ mod tests {
             "
             .to_string(),
         );
-        let options = CommonOpts::new();
+        let options = CommonOpts::from_iter([""].iter());
 
         let items = tokenizer.tokenize(&options);
         let ledger = items.to_ledger(&options).unwrap();

--- a/src/models.rs
+++ b/src/models.rs
@@ -538,7 +538,7 @@ mod tests {
             "
             .to_string(),
         );
-        let options = CommonOpts::from_iter([""].iter());
+        let options = CommonOpts::from_iter(["", "-f", ""].iter());
 
         let items = tokenizer.tokenize(&options);
         let ledger = items.to_ledger(&options).unwrap();

--- a/src/models/price.rs
+++ b/src/models/price.rs
@@ -306,15 +306,15 @@ mod tests {
     use crate::parser::Tokenizer;
     use crate::CommonOpts;
     use chrono::Utc;
-    use structopt::StructOpt;
     use std::path::PathBuf;
+    use structopt::StructOpt;
 
     #[test]
     fn test_graph() {
         // Copy from balance command
         let path = PathBuf::from("tests/example_files/demo.ledger");
         let mut tokenizer = Tokenizer::from(&path);
-        let options = CommonOpts::from_iter([""].iter());
+        let options = CommonOpts::from_iter(["", "-f", ""].iter());
         let items = tokenizer.tokenize(&options);
         let ledger = items.to_ledger(&options).unwrap();
 

--- a/src/models/price.rs
+++ b/src/models/price.rs
@@ -306,6 +306,7 @@ mod tests {
     use crate::parser::Tokenizer;
     use crate::CommonOpts;
     use chrono::Utc;
+    use structopt::StructOpt;
     use std::path::PathBuf;
 
     #[test]
@@ -313,7 +314,7 @@ mod tests {
         // Copy from balance command
         let path = PathBuf::from("tests/example_files/demo.ledger");
         let mut tokenizer = Tokenizer::from(&path);
-        let options = CommonOpts::new();
+        let options = CommonOpts::from_iter([""].iter());
         let items = tokenizer.tokenize(&options);
         let ledger = items.to_ledger(&options).unwrap();
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -231,13 +231,15 @@ impl<'a> Tokenizer<'a> {
 }
 #[cfg(test)]
 mod tests {
+    use structopt::StructOpt;
+
     use super::*;
 
     #[test]
     fn test_empty_string() {
         let content = "".to_string();
         let mut tokenizer = Tokenizer::from(content);
-        let items = tokenizer.tokenize(&CommonOpts::new());
+        let items = tokenizer.tokenize(&CommonOpts::from_iter([""].iter()));
         assert_eq!(items.len(), 0, "Should be empty");
     }
 
@@ -245,7 +247,7 @@ mod tests {
     fn test_only_spaces() {
         let content = "\n\n\n\n\n".to_string();
         let mut tokenizer = Tokenizer::from(content);
-        let items = tokenizer.tokenize(&CommonOpts::new());
+        let items = tokenizer.tokenize(&CommonOpts::from_iter([""].iter()));
         assert_eq!(items.len(), 0, "Should be empty")
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -239,7 +239,7 @@ mod tests {
     fn test_empty_string() {
         let content = "".to_string();
         let mut tokenizer = Tokenizer::from(content);
-        let items = tokenizer.tokenize(&CommonOpts::from_iter([""].iter()));
+        let items = tokenizer.tokenize(&CommonOpts::from_iter(["", "-f", ""].iter()));
         assert_eq!(items.len(), 0, "Should be empty");
     }
 
@@ -247,7 +247,7 @@ mod tests {
     fn test_only_spaces() {
         let content = "\n\n\n\n\n".to_string();
         let mut tokenizer = Tokenizer::from(content);
-        let items = tokenizer.tokenize(&CommonOpts::from_iter([""].iter()));
+        let items = tokenizer.tokenize(&CommonOpts::from_iter(["", "-f", ""].iter()));
         assert_eq!(items.len(), 0, "Should be empty")
     }
 }

--- a/src/parser/tokenizers/payee.rs
+++ b/src/parser/tokenizers/payee.rs
@@ -56,7 +56,7 @@ mod tests {
     fn parse_ko() {
         let input = "payee ACME  ; From the Looney Tunes\n\tWrong Acme, Inc.\n".to_string();
         let mut tokenizer = Tokenizer::from(input);
-        let items = tokenizer.tokenize(&CommonOpts::from_iter([""].iter()));
+        let items = tokenizer.tokenize(&CommonOpts::from_iter(["", "-f", ""].iter()));
         assert_eq!(items.payees.len(), 0);
     }
 
@@ -65,7 +65,7 @@ mod tests {
         let input = "payee ACME\n\talias Acme, Inc.\n".to_string();
         let mut tokenizer = Tokenizer::from(input);
 
-        let items = tokenizer.tokenize(&CommonOpts::from_iter([""].iter()));
+        let items = tokenizer.tokenize(&CommonOpts::from_iter(["", "-f", ""].iter()));
         assert_eq!(items.payees.len(), 1);
 
         assert!(items.payees.get("acme, inc.").is_ok());

--- a/src/parser/tokenizers/payee.rs
+++ b/src/parser/tokenizers/payee.rs
@@ -46,6 +46,8 @@ impl<'a> Tokenizer<'a> {
 
 #[cfg(test)]
 mod tests {
+    use structopt::StructOpt;
+
     use super::*;
     use crate::{models::HasName, CommonOpts};
 
@@ -54,7 +56,7 @@ mod tests {
     fn parse_ko() {
         let input = "payee ACME  ; From the Looney Tunes\n\tWrong Acme, Inc.\n".to_string();
         let mut tokenizer = Tokenizer::from(input);
-        let items = tokenizer.tokenize(&CommonOpts::new());
+        let items = tokenizer.tokenize(&CommonOpts::from_iter([""].iter()));
         assert_eq!(items.payees.len(), 0);
     }
 
@@ -63,7 +65,7 @@ mod tests {
         let input = "payee ACME\n\talias Acme, Inc.\n".to_string();
         let mut tokenizer = Tokenizer::from(input);
 
-        let items = tokenizer.tokenize(&CommonOpts::new());
+        let items = tokenizer.tokenize(&CommonOpts::from_iter([""].iter()));
         assert_eq!(items.payees.len(), 1);
 
         assert!(items.payees.get("acme, inc.").is_ok());

--- a/src/parser/tokenizers/tag.rs
+++ b/src/parser/tokenizers/tag.rs
@@ -42,13 +42,15 @@ impl<'a> Tokenizer<'a> {
 
 #[cfg(test)]
 mod tests {
+    use structopt::StructOpt;
+
     use super::*;
     use crate::{models::HasName, CommonOpts};
 
     #[test]
     fn test_spaces_in_tag_names() {
         let mut tokenizer = Tokenizer::from("tag   A tag name with spaces   ".to_string());
-        let items = tokenizer.tokenize(&CommonOpts::new());
+        let items = tokenizer.tokenize(&CommonOpts::from_iter([""].iter()));
         let tag = &items.tags[0];
         assert_eq!(tag.get_name(), "A tag name with spaces");
     }

--- a/src/parser/tokenizers/tag.rs
+++ b/src/parser/tokenizers/tag.rs
@@ -50,7 +50,7 @@ mod tests {
     #[test]
     fn test_spaces_in_tag_names() {
         let mut tokenizer = Tokenizer::from("tag   A tag name with spaces   ".to_string());
-        let items = tokenizer.tokenize(&CommonOpts::from_iter([""].iter()));
+        let items = tokenizer.tokenize(&CommonOpts::from_iter(["", "-f", ""].iter()));
         let tag = &items.tags[0];
         assert_eq!(tag.get_name(), "A tag name with spaces");
     }

--- a/src/parser/tokenizers/transaction.rs
+++ b/src/parser/tokenizers/transaction.rs
@@ -5,7 +5,6 @@ use crate::parser::Tokenizer;
 use chrono::NaiveDate;
 use num::{rational::BigRational, BigInt};
 use pest::iterators::Pair;
-use structopt::StructOpt;
 
 impl<'a> Tokenizer<'a> {
     /// Parses a transaction
@@ -254,7 +253,7 @@ mod tests {
             .to_string(),
         );
 
-        let parsed = tokenizer.tokenize(&CommonOpts::from_iter([""].iter()));
+        let parsed = tokenizer.tokenize(&CommonOpts::from_iter(["", "-f", ""].iter()));
         let transaction = &parsed.transactions[0];
         assert_eq!(transaction.cleared, Cleared::NotCleared);
         assert_eq!(transaction.status, TransactionStatus::NotChecked);

--- a/src/parser/tokenizers/transaction.rs
+++ b/src/parser/tokenizers/transaction.rs
@@ -238,6 +238,8 @@ fn parse_posting(
 }
 #[cfg(test)]
 mod tests {
+    use structopt::StructOpt;
+
     use super::*;
     use crate::models::{Cleared, TransactionStatus};
     use crate::{parser::Tokenizer, CommonOpts};

--- a/src/parser/tokenizers/transaction.rs
+++ b/src/parser/tokenizers/transaction.rs
@@ -5,6 +5,7 @@ use crate::parser::Tokenizer;
 use chrono::NaiveDate;
 use num::{rational::BigRational, BigInt};
 use pest::iterators::Pair;
+use structopt::StructOpt;
 
 impl<'a> Tokenizer<'a> {
     /// Parses a transaction
@@ -253,7 +254,7 @@ mod tests {
             .to_string(),
         );
 
-        let parsed = tokenizer.tokenize(&CommonOpts::new());
+        let parsed = tokenizer.tokenize(&CommonOpts::from_iter([""].iter()));
         let transaction = &parsed.transactions[0];
         assert_eq!(transaction.cleared, Cleared::NotCleared);
         assert_eq!(transaction.status, TransactionStatus::NotChecked);

--- a/tests/test_accounts.rs
+++ b/tests/test_accounts.rs
@@ -48,10 +48,10 @@ fn test_account_names() {
 
     for (i, mut tokenizer) in tokenizers.into_iter().enumerate() {
         println!("Test case #{}", i);
-        let parsed = tokenizer.tokenize(&CommonOpts::from_iter([""].iter()));
+        let parsed = tokenizer.tokenize(&CommonOpts::from_iter(["", "-f", ""].iter()));
         let mut num_accounts = parsed.accounts.len();
         assert_eq!(num_accounts, 0, "There should be no accounts when parsed");
-        let mut options = CommonOpts::from_iter([""].iter());
+        let mut options = CommonOpts::from_iter(["", "-f", ""].iter());
         options.no_balance_check = true;
         num_accounts = parsed.to_ledger(&options).unwrap().accounts.len();
         assert_eq!(num_accounts, 2, "There should be two accounts");
@@ -68,7 +68,7 @@ fn test_account_directive() {
             .to_string(),
     );
 
-    let parsed = tokenizer.tokenize(&CommonOpts::from_iter([""].iter()));
+    let parsed = tokenizer.tokenize(&CommonOpts::from_iter(["", "-f", ""].iter()));
     let num_accounts = parsed.accounts.len();
     assert_eq!(num_accounts, 1, "Parse one account")
 }

--- a/tests/test_accounts.rs
+++ b/tests/test_accounts.rs
@@ -1,4 +1,5 @@
 use dinero::{parser::Tokenizer, CommonOpts};
+use structopt::StructOpt;
 
 #[test]
 fn test_account_names() {
@@ -47,10 +48,10 @@ fn test_account_names() {
 
     for (i, mut tokenizer) in tokenizers.into_iter().enumerate() {
         println!("Test case #{}", i);
-        let parsed = tokenizer.tokenize(&CommonOpts::new());
+        let parsed = tokenizer.tokenize(&CommonOpts::from_iter([""].iter()));
         let mut num_accounts = parsed.accounts.len();
         assert_eq!(num_accounts, 0, "There should be no accounts when parsed");
-        let mut options = CommonOpts::new();
+        let mut options = CommonOpts::from_iter([""].iter());
         options.no_balance_check = true;
         num_accounts = parsed.to_ledger(&options).unwrap().accounts.len();
         assert_eq!(num_accounts, 2, "There should be two accounts");
@@ -67,7 +68,7 @@ fn test_account_directive() {
             .to_string(),
     );
 
-    let parsed = tokenizer.tokenize(&CommonOpts::new());
+    let parsed = tokenizer.tokenize(&CommonOpts::from_iter([""].iter()));
     let num_accounts = parsed.accounts.len();
     assert_eq!(num_accounts, 1, "Parse one account")
 }

--- a/tests/test_balances.rs
+++ b/tests/test_balances.rs
@@ -1,4 +1,5 @@
 use dinero::{parser::Tokenizer, CommonOpts};
+use structopt::StructOpt;
 #[test]
 fn test_balances() {
     let mut tokenizer = Tokenizer::from(
@@ -17,7 +18,7 @@ fn test_balances() {
 "
         .to_string(),
     );
-    let options = CommonOpts::new();
+    let options = CommonOpts::from_iter([""].iter());
     let parsed = tokenizer.tokenize(&options);
     let ledger = parsed.to_ledger(&options);
     assert!(ledger.is_ok(), "This should balance");

--- a/tests/test_balances.rs
+++ b/tests/test_balances.rs
@@ -18,7 +18,7 @@ fn test_balances() {
 "
         .to_string(),
     );
-    let options = CommonOpts::from_iter([""].iter());
+    let options = CommonOpts::from_iter(["", "-f", ""].iter());
     let parsed = tokenizer.tokenize(&options);
     let ledger = parsed.to_ledger(&options);
     assert!(ledger.is_ok(), "This should balance");

--- a/tests/test_commands.rs
+++ b/tests/test_commands.rs
@@ -488,8 +488,6 @@ fn args_only() {
     test_args(args_2);
 }
 
-
-
 #[test]
 /// Check the collapse option
 fn related() {
@@ -500,7 +498,7 @@ fn related() {
         "-f",
         "tests/example_files/collapse_demo.ledger",
         "--related",
-        "travel"
+        "travel",
     ];
     let assert_1 = Command::cargo_bin("dinero").unwrap().args(args).assert();
     let output = String::from_utf8(assert_1.get_output().to_owned().stdout).unwrap();

--- a/tests/test_currency_formats.rs
+++ b/tests/test_currency_formats.rs
@@ -1,4 +1,3 @@
-use std::borrow::BorrowMut;
 use std::rc::Rc;
 
 use chrono::Utc;
@@ -41,7 +40,7 @@ commodity ACME
         "
         .to_string(),
     );
-    let options = CommonOpts::from_iter([""].iter());
+    let options = CommonOpts::from_iter(["", "-f", ""].iter());
     let items = tokenizer.tokenize(&options);
     let ledger = items.to_ledger(&options).unwrap();
     let eur = ledger.get_commodities().get("eur").unwrap();

--- a/tests/test_currency_formats.rs
+++ b/tests/test_currency_formats.rs
@@ -7,6 +7,7 @@ use dinero::parser::Tokenizer;
 use dinero::{models::conversion, CommonOpts};
 use num::traits::Inv;
 use num::{BigInt, BigRational};
+use structopt::StructOpt;
 
 #[test]
 fn currency_formats() {
@@ -40,7 +41,7 @@ commodity ACME
         "
         .to_string(),
     );
-    let options = CommonOpts::new();
+    let options = CommonOpts::from_iter([""].iter());
     let items = tokenizer.tokenize(&options);
     let ledger = items.to_ledger(&options).unwrap();
     let eur = ledger.get_commodities().get("eur").unwrap();

--- a/tests/test_exchange.rs
+++ b/tests/test_exchange.rs
@@ -30,7 +30,7 @@ P 2020-07-01 EUR 1.5 USD
         "
         .to_string(),
     );
-    let options = CommonOpts::from_iter([""].iter());
+    let options = CommonOpts::from_iter(["", "-f", ""].iter());
     let items = tokenizer.tokenize(&options);
     let ledger = items.to_ledger(&options).unwrap();
     let eur = ledger.get_commodities().get("eur").unwrap();

--- a/tests/test_exchange.rs
+++ b/tests/test_exchange.rs
@@ -3,6 +3,7 @@ use dinero::parser::Tokenizer;
 use dinero::{models::conversion, CommonOpts};
 use num::traits::Inv;
 use num::{BigInt, BigRational};
+use structopt::StructOpt;
 
 #[test]
 fn exchange() {
@@ -29,7 +30,7 @@ P 2020-07-01 EUR 1.5 USD
         "
         .to_string(),
     );
-    let options = CommonOpts::new();
+    let options = CommonOpts::from_iter([""].iter());
     let items = tokenizer.tokenize(&options);
     let ledger = items.to_ledger(&options).unwrap();
     let eur = ledger.get_commodities().get("eur").unwrap();

--- a/tests/test_failures.rs
+++ b/tests/test_failures.rs
@@ -15,12 +15,12 @@ fn not_money() {
 "
         .to_string(),
     );
-    let parsed = tokenizer.tokenize(&CommonOpts::from_iter([""].iter()));
+    let parsed = tokenizer.tokenize(&CommonOpts::from_iter(["", "-f", ""].iter()));
 
     // It parses -- it has not panicked
     assert!(true);
 
     // But to a wrong ledger -- panics!
-    let _ledger = parsed.to_ledger(&CommonOpts::from_iter([""].iter()));
+    let _ledger = parsed.to_ledger(&CommonOpts::from_iter(["", "-f", ""].iter()));
     unreachable!("This has panicked")
 }

--- a/tests/test_failures.rs
+++ b/tests/test_failures.rs
@@ -1,4 +1,5 @@
 use dinero::{parser::Tokenizer, CommonOpts};
+use structopt::StructOpt;
 
 #[test]
 #[should_panic(expected = "Should be money.")]
@@ -14,12 +15,12 @@ fn not_money() {
 "
         .to_string(),
     );
-    let parsed = tokenizer.tokenize(&CommonOpts::new());
+    let parsed = tokenizer.tokenize(&CommonOpts::from_iter([""].iter()));
 
     // It parses -- it has not panicked
     assert!(true);
 
     // But to a wrong ledger -- panics!
-    let _ledger = parsed.to_ledger(&CommonOpts::new());
+    let _ledger = parsed.to_ledger(&CommonOpts::from_iter([""].iter()));
     unreachable!("This has panicked")
 }

--- a/tests/test_include.rs
+++ b/tests/test_include.rs
@@ -2,14 +2,14 @@ use dinero::parser::Tokenizer;
 use dinero::CommonOpts;
 
 use assert_cmd::Command;
-use structopt::StructOpt;
 use std::path::PathBuf;
+use structopt::StructOpt;
 
 #[test]
 fn test_include() {
     let p1 = PathBuf::from("tests/example_files/include.ledger".to_string());
     let mut tokenizer: Tokenizer = Tokenizer::from(&p1);
-    let _res = tokenizer.tokenize(&CommonOpts::from_iter([""].iter()));
+    let _res = tokenizer.tokenize(&CommonOpts::from_iter(["", "-f", ""].iter()));
     // simply that it does not panic
     // todo change for something meaningful
     assert!(true);
@@ -19,7 +19,7 @@ fn test_include() {
 fn test_build_ledger_from_demo() {
     let p1 = PathBuf::from("tests/example_files/demo.ledger".to_string());
     let mut tokenizer: Tokenizer = Tokenizer::from(&p1);
-    let options = CommonOpts::from_iter([""].iter());
+    let options = CommonOpts::from_iter(["", "-f", ""].iter());
     let items = tokenizer.tokenize(&options);
     let ledger = items.to_ledger(&options);
     assert!(ledger.is_ok());
@@ -35,12 +35,12 @@ fn test_fail() {
 "
         .to_string(),
     );
-    let parsed = tokenizer.tokenize(&CommonOpts::from_iter([""].iter()));
+    let parsed = tokenizer.tokenize(&CommonOpts::from_iter(["", "-f", ""].iter()));
     // It parses
     assert!(true);
 
     // But to a wrong ledger
-    let ledger = parsed.to_ledger(&CommonOpts::from_iter([""].iter()));
+    let ledger = parsed.to_ledger(&CommonOpts::from_iter(["", "-f", ""].iter()));
     assert!(ledger.is_err());
 }
 
@@ -54,7 +54,7 @@ fn comment_no_spaces() {
         "
         .to_string(),
     );
-    let options = CommonOpts::from_iter([""].iter());
+    let options = CommonOpts::from_iter(["", "-f", ""].iter());
     let items = tokenizer.tokenize(&options);
     let ledger = items.to_ledger(&options);
     assert!(ledger.is_ok());
@@ -69,7 +69,7 @@ fn comment_spaces() {
         "
         .to_string(),
     );
-    let options = CommonOpts::from_iter([""].iter());
+    let options = CommonOpts::from_iter(["", "-f", ""].iter());
     let items = tokenizer.tokenize(&options);
     let ledger = items.to_ledger(&options);
     assert!(ledger.is_ok());

--- a/tests/test_include.rs
+++ b/tests/test_include.rs
@@ -2,13 +2,14 @@ use dinero::parser::Tokenizer;
 use dinero::CommonOpts;
 
 use assert_cmd::Command;
+use structopt::StructOpt;
 use std::path::PathBuf;
 
 #[test]
 fn test_include() {
     let p1 = PathBuf::from("tests/example_files/include.ledger".to_string());
     let mut tokenizer: Tokenizer = Tokenizer::from(&p1);
-    let _res = tokenizer.tokenize(&CommonOpts::new());
+    let _res = tokenizer.tokenize(&CommonOpts::from_iter([""].iter()));
     // simply that it does not panic
     // todo change for something meaningful
     assert!(true);
@@ -18,7 +19,7 @@ fn test_include() {
 fn test_build_ledger_from_demo() {
     let p1 = PathBuf::from("tests/example_files/demo.ledger".to_string());
     let mut tokenizer: Tokenizer = Tokenizer::from(&p1);
-    let options = CommonOpts::new();
+    let options = CommonOpts::from_iter([""].iter());
     let items = tokenizer.tokenize(&options);
     let ledger = items.to_ledger(&options);
     assert!(ledger.is_ok());
@@ -34,12 +35,12 @@ fn test_fail() {
 "
         .to_string(),
     );
-    let parsed = tokenizer.tokenize(&CommonOpts::new());
+    let parsed = tokenizer.tokenize(&CommonOpts::from_iter([""].iter()));
     // It parses
     assert!(true);
 
     // But to a wrong ledger
-    let ledger = parsed.to_ledger(&CommonOpts::new());
+    let ledger = parsed.to_ledger(&CommonOpts::from_iter([""].iter()));
     assert!(ledger.is_err());
 }
 
@@ -53,7 +54,7 @@ fn comment_no_spaces() {
         "
         .to_string(),
     );
-    let options = CommonOpts::new();
+    let options = CommonOpts::from_iter([""].iter());
     let items = tokenizer.tokenize(&options);
     let ledger = items.to_ledger(&options);
     assert!(ledger.is_ok());
@@ -68,7 +69,7 @@ fn comment_spaces() {
         "
         .to_string(),
     );
-    let options = CommonOpts::new();
+    let options = CommonOpts::from_iter([""].iter());
     let items = tokenizer.tokenize(&options);
     let ledger = items.to_ledger(&options);
     assert!(ledger.is_ok());


### PR DESCRIPTION
- modify everything so that ```CommonOpts::new``` is not used
- fix tests and fmt

No need for ```CommonOpts::new``` as it was only used in test code and not in actual code. Another option could be to include it in ```commons.rs``` for test code.
